### PR TITLE
blog: Product Updates April 2026 - v0.21.0

### DIFF
--- a/content/blogs/v021-product-updates.md
+++ b/content/blogs/v021-product-updates.md
@@ -7,19 +7,29 @@ author: Brandon Apol
 
 Hey folks, welcome to our first product design report. This blog post is a little different, we're just going to talk about some of the new features AutoButler has built in the last few weeks.
 
+## Document Editor
 First off, we're stoked to talk about our new document editor. We can't wait for users to play with this; it comes with default dark mode, straightforward tooling, auto save, and PDF support. We've been looking into existing complaints about Google Docs and Microsoft Word, and we're optimistic about where this is going.
 
+## Spreadsheet Editor
 On the heels of document editing is an initial foray into a spreadsheet editor; turns out, a lot of the sluggishness and performance problems with existing spreadsheet editors results from observability and tracking. Yup, they've got so much gunk in there trying to track stuff, like the position of your mouse, that the whole thing is slowed down. We don't care about that stuff, and AutoButler never phones home with data, so there's not really a benefit.
 
+## Cirrus Updates
 We've also made updates to the file browser, which we call Cirrus. We've called it that because cirrus clouds are the highest layer of clouds, and we want our product to be the highest quality cloud offering imaginable - a totally local cloud in your home. We're pleased to point out that we have a better zip file handling solution to all other cloud providers; Google Drive and iCloud have less support for zip files than we do now. You can actually open zipped files without unzipping them, saving you storage space on your drive! The files now show real-time updates to the UI, so if your spouse changes a file name you never are out-of-sync with them. We also have filtering per-device, so you can see what files exist on a flash drive at the parent level and can move files between external hard drives easily.
 
+## Remote Access
 On a super practical level we've added remote access, meaning that when we get our permission from Apple to start sharing the iOS app, you can access your data from the grocery store, securely. This is using a clever but battle-tested technology that's similar to a VPN, but instead of pretending to be an edgy teenager in Sweden, you are actually remotely jumping into your home. We've spent a lot of time making sure this is secure, and a follow up blog will discuss how exactly we did this, but it's actually more common to do this than you would think. The short version is you'll be able to access your data securely from anywhere, but that data will be encrypted and still private in your home.
 
+## Photos Library
 We've made great progress with the Photos library as well; I've been talking with my sister, who is an amateur photographer and expert optics engineer, about making our photos library into something super powerful for image editing. We now have the ability to add and manage albums, we can see photo metadata on individual photo pages, and basic editing like rotating is in place. We also have a default favorites album and the ability to add photos to that album. There's way more coming here, but we're plotting and scheming a 1:1 replacement for existing cloud software like the Google suite or iCloud.
 
+## Join the Certified Hater Program
 As always, we're looking for early testers of the product, so if you have strong opinions and don't know how to code, please reach out to be part of our Certified Hater Program. If you don't like how we're doing parts of this, or if you have ideas for things you think this should include, feel free to contact us; the best way is still by adding GitHub issues at our feature link. We need people to tell us what we're not doing well so we can make this thing better all the time. Joining the program comes with a steep discount on the product, so you'll want to be on this list, and we're limiting it to a run of roughly 10 people; as a reminder, we include lifetime software updates for free on all our products, so getting in early doesn't mean you'll miss out down the road, either.
+
+___
 
 We are so stoked to share this with you in version 0.21, and soon we'll have all our basic features in place and tested out. We love you all and want you to have a product you are excited about, and want to have people on board who value privacy and want to show the existing system that you can still make a consumer-centric product without selling your soul. Stay rad, and we'll see you in the next update.
 
 Grace and peace,
 Brandon
+
+

--- a/content/blogs/v021-product-updates.md
+++ b/content/blogs/v021-product-updates.md
@@ -1,0 +1,25 @@
+---
+title: Product Updates April 2026 - v0.21.0
+description: Our first product design report — document editor, spreadsheet editor, Cirrus updates, remote access, and Photos library improvements.
+date: 2026-04-27
+author: Brandon Apol
+---
+
+Hey folks, welcome to our first product design report. This blog post is a little different, we're just going to talk about some of the new features AutoButler has built in the last few weeks.
+
+First off, we're stoked to talk about our new document editor. We can't wait for users to play with this; it comes with default dark mode, straightforward tooling, auto save, and PDF support. We've been looking into existing complaints about Google Docs and Microsoft Word, and we're optimistic about where this is going.
+
+On the heels of document editing is an initial foray into a spreadsheet editor; turns out, a lot of the sluggishness and performance problems with existing spreadsheet editors results from observability and tracking. Yup, they've got so much gunk in there trying to track stuff, like the position of your mouse, that the whole thing is slowed down. We don't care about that stuff, and AutoButler never phones home with data, so there's not really a benefit.
+
+We've also made updates to the file browser, which we call Cirrus. We've called it that because cirrus clouds are the highest layer of clouds, and we want our product to be the highest quality cloud offering imaginable - a totally local cloud in your home. We're pleased to point out that we have a better zip file handling solution to all other cloud providers; Google Drive and iCloud have less support for zip files than we do now. You can actually open zipped files without unzipping them, saving you storage space on your drive! The files now show real-time updates to the UI, so if your spouse changes a file name you never are out-of-sync with them. We also have filtering per-device, so you can see what files exist on a flash drive at the parent level and can move files between external hard drives easily.
+
+On a super practical level we've added remote access, meaning that when we get our permission from Apple to start sharing the iOS app, you can access your data from the grocery store, securely. This is using a clever but battle-tested technology that's similar to a VPN, but instead of pretending to be an edgy teenager in Sweden, you are actually remotely jumping into your home. We've spent a lot of time making sure this is secure, and a follow up blog will discuss how exactly we did this, but it's actually more common to do this than you would think. The short version is you'll be able to access your data securely from anywhere, but that data will be encrypted and still private in your home.
+
+We've made great progress with the Photos library as well; I've been talking with my sister, who is an amateur photographer and expert optics engineer, about making our photos library into something super powerful for image editing. We now have the ability to add and manage albums, we can see photo metadata on individual photo pages, and basic editing like rotating is in place. We also have a default favorites album and the ability to add photos to that album. There's way more coming here, but we're plotting and scheming a 1:1 replacement for existing cloud software like the Google suite or iCloud.
+
+As always, we're looking for early testers of the product, so if you have strong opinions and don't know how to code, please reach out to be part of our Certified Hater Program. If you don't like how we're doing parts of this, or if you have ideas for things you think this should include, feel free to contact us; the best way is still by adding GitHub issues at our feature link. We need people to tell us what we're not doing well so we can make this thing better all the time. Joining the program comes with a steep discount on the product, so you'll want to be on this list, and we're limiting it to a run of roughly 10 people; as a reminder, we include lifetime software updates for free on all our products, so getting in early doesn't mean you'll miss out down the road, either.
+
+We are so stoked to share this with you in version 0.21, and soon we'll have all our basic features in place and tested out. We love you all and want you to have a product you are excited about, and want to have people on board who value privacy and want to show the existing system that you can still make a consumer-centric product without selling your soul. Stay rad, and we'll see you in the next update.
+
+Grace and peace,
+Brandon

--- a/package-lock.json
+++ b/package-lock.json
@@ -7378,9 +7378,9 @@
       "license": "MIT"
     },
     "node_modules/cytoscape": {
-      "version": "3.33.1",
-      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
-      "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
+      "version": "3.33.2",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
+      "integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -15618,9 +15618,9 @@
       }
     },
     "node_modules/stylis": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
-      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
       "license": "MIT"
     },
     "node_modules/supports-color": {


### PR DESCRIPTION
Adds the v0.21.0 product update blog post.

Content matches the email campaign draft created in Mailchimp ("Blog: Product Updates April 2026 - v0.21.0"). Once this merges, the Mailchimp CTA link can be updated to point at the live post URL.