### PR TITLE
rebrand: reword global site description, blog copy to first person

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -14,7 +14,7 @@ export default defineNuxtConfig({
   app: {
     head: {
       meta: [
-        { name: "description", content: "AutoButler — your personal home data butler. Self-hosted file management, backup, and media serving." },
+        { name: "description", content: "AutoButler — the company behind Quark, a self-hosted personal cloud device. No subscriptions, no data mining, just your files on hardware you own." },
         { property: "og:site_name", content: "AutoButler" },
         { property: "og:type", content: "website" },
         { property: "og:image", content: "https://autobutler.org/android-chrome-512x512.png" },

--- a/pages/blogs/index.vue
+++ b/pages/blogs/index.vue
@@ -3,9 +3,7 @@
     <PageContainer>
       <div class="blogs-header">
         <h1>Blog</h1>
-        <p class="subtitle">
-          Updates, insights, and stories from the AutoButler team
-        </p>
+        <p class="subtitle">Updates, insights, and stories from our team</p>
       </div>
 
       <div v-if="articles && articles.length > 0" class="blog-list">
@@ -51,16 +49,16 @@ interface BlogPost extends ContentCollectionItem {
 
 useSeoMeta({
   title: "Blog — AutoButler",
-  description: "Updates, insights, and stories from the AutoButler team.",
+  description: "Updates, insights, and stories from our team.",
   ogTitle: "AutoButler Blog",
-  ogDescription: "Updates, insights, and stories from the AutoButler team.",
+  ogDescription: "Updates, insights, and stories from our team.",
   ogType: "website",
   ogUrl: "https://autobutler.org/blogs",
   ogSiteName: "AutoButler",
   ogImage: "https://autobutler.org/android-chrome-512x512.png",
   twitterCard: "summary",
   twitterTitle: "AutoButler Blog",
-  twitterDescription: "Updates, insights, and stories from the AutoButler team.",
+  twitterDescription: "Updates, insights, and stories from our team.",
   twitterImage: "https://autobutler.org/android-chrome-512x512.png",
 });
 


### PR DESCRIPTION
Closes #116

## What
Executes #116 (blog & global SEO/OG defaults), scoped to autobutler.org. The quark.autobutler.org side of this ticket shipped separately in quark.autobutler.org#12 (per-page OG meta on docs pages, plus a theme-color tag).

## Changes
- `nuxt.config.ts`: global site description was describing Quark ("your personal home data butler"), which per #110 is no longer accurate — AutoButler is the company behind Quark, not the product. Reworded.
- `pages/blogs/index.vue`: "Updates, insights, and stories from the AutoButler team" → "...from our team", per #110's first-person voice decision. This is company-level content (blog stays on autobutler.org) so no product-name swap was needed, just the voice.
- Left `pages/blogs/[...slug].vue`'s fallback strings ("AutoButler Blog", "Read more on the AutoButler blog.") unchanged — neither references the product or uses third-person "team" phrasing, so they don't fall under this ticket's scope.
- Left `pages/contact.vue`'s "the AutoButler team" phrasing unchanged — that's tracked under #114, not this ticket.

## Test plan
- [x] `npx eslint` on changed files — clean
- [x] `npx nuxt build` — succeeds, 52 routes prerendered
- [x] Verified generated `blogs/index.html` contains "stories from our team" in the subtitle, meta description, OG description, and Twitter description