### PR TITLE
rebrand: point header Support link at quark.autobutler.org

### DIFF
--- a/components/ButlerHeader.vue
+++ b/components/ButlerHeader.vue
@@ -11,7 +11,7 @@
         <!-- Single forward to the Quark product site — only one product exists today.
              Revert to a "Products" dropdown when a second product ships, see #121. -->
         <a href="https://quark.autobutler.org" class="quark-link">Quark</a>
-        <NuxtLink to="/support">Support</NuxtLink>
+        <a href="https://quark.autobutler.org/support">Support</a>
         <NuxtLink to="/community">Community</NuxtLink>
         <NuxtLink to="/blogs">Blog</NuxtLink>
         <NuxtLink to="/about">About</NuxtLink>
@@ -48,7 +48,7 @@
         <!-- Single forward to the Quark product site — see #121 for reintroducing
              a Products list once there's more than one. -->
         <a href="https://quark.autobutler.org" @click="closeMobileMenu">Quark</a>
-        <NuxtLink to="/support" @click="closeMobileMenu">Support</NuxtLink>
+        <a href="https://quark.autobutler.org/support" @click="closeMobileMenu">Support</a>
         <NuxtLink to="/community" @click="closeMobileMenu">Community</NuxtLink>
         <NuxtLink to="/blogs" @click="closeMobileMenu">Blog</NuxtLink>
         <NuxtLink to="/about" @click="closeMobileMenu">About</NuxtLink>


### PR DESCRIPTION
## What
Support content moved to quark.autobutler.org (autobutler-org/quark.autobutler.org#17), same pattern as docs before it. Repoints the header's Support link there instead of this site's own `/support` page.

## Changes
- `components/ButlerHeader.vue` — Support link (desktop + mobile nav) now points at `https://quark.autobutler.org/support` instead of the local `/support` route

## Notes
- Doesn't delete `pages/support.vue` here yet — leaving that cleanup for a follow-up, same as docs (#115) left `content/docs/` and `pages/docs/` in place after the header stopped linking to them.

## Test plan
- [x] `npx eslint components/ButlerHeader.vue` — clean
- [x] `npx nuxt build` — succeeds, 52 routes prerendered
- [x] Verified the generated homepage's header markup links to `https://quark.autobutler.org/support`