### PR TITLE
style: drop the rocket emoji from the waitlist page

### DIFF
--- a/pages/waitlist.vue
+++ b/pages/waitlist.vue
@@ -20,7 +20,7 @@
       </div>
 
       <div class="launch-info">
-        <p>🚀 <strong>Coming Summer 2026</strong></p>
+        <p><strong>Coming Summer 2026</strong></p>
         <p>
           We're working hard to bring you the best self-hosted storage solution.
           Stay tuned!


### PR DESCRIPTION
## What
Just the emoji, per Brandon's note — the launch-note copy stays as originally written.

## Changes
- `pages/waitlist.vue` — removed the rocket emoji from the launch note (`🚀 Coming Summer 2026` → `Coming Summer 2026`). No other content changed.

## Flagging, not fixing here
`content/docs/how-it-works.md`'s mermaid diagrams use emoji in node labels (📱 🏠 🤖 💾 💻 ☁️). Didn't touch those in this PR — removing them means either stripping the emoji from working diagrams or reworking the diagrams entirely. Let me know if you want either.

## Test plan
- [x] `npx eslint pages/waitlist.vue` — clean
- [x] `npx nuxt build` — succeeds, 52 routes prerendered